### PR TITLE
spanish translations

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,11 @@ module.exports.fr = ['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendred
 module.exports.fr.abbr = ['dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam'];
 module.exports.fr.short = ['di', 'lu', 'ma', 'me', 'je', 've', 'sa'];
 
+// Spanish translation
+module.exports.fr = ['domingo', 'lunes', 'martes', 'miercoles', 'jueves', 'viernes', 'sabado'];
+module.exports.fr.abbr = ['dom', 'lun', 'mar', 'mir', 'jue', 'vie', 'sab'];
+module.exports.fr.short = ['do', 'lu', 'ma', 'mi', 'ju', 'vi', 'sa'];
+
 // In order not to break compatibility
 module.exports = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 module.exports.abbr = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];


### PR DESCRIPTION
did not use written accents

miercoles should be miércoles
sabado should be sábado
